### PR TITLE
Add Synapse (Matrix homeserver) user-agent to `generate_embed_user_agents`

### DIFF
--- a/server.py
+++ b/server.py
@@ -38,6 +38,7 @@ generate_embed_user_agents = {
 	"Mozilla/5.0 (compatible; Discordbot/2.0; +https://discordapp.com)", 
 	"TelegramBot (like TwitterBot)", 
 	"Mozilla/5.0 (compatible; January/1.0; +https://gitlab.insrt.uk/revolt/january)", 
+	"Synapse (bot; +https://github.com/matrix-org/synapse)",
 	"test",
 }
 thumbnail_cutoff: int = 5242880  # 5MB in bytes


### PR DESCRIPTION
This adds the user-agent for the [Synapse](https://github.com/element-hq/synapse) Matrix homeserver to the list of user-agents which will generate a link preview without a 302 redirect.